### PR TITLE
fix(): assertClippingGroup

### DIFF
--- a/packages/fabric/src/EraserBrush.ts
+++ b/packages/fabric/src/EraserBrush.ts
@@ -30,13 +30,15 @@ function walk(objects: FabricObject[], path: Path): FabricObject[] {
 
 const assertClippingGroup = (object: fabric.FabricObject) => {
   const curr = object.clipPath;
-  const next =
-    curr instanceof ClippingGroup
-      ? curr
-      : new ClippingGroup([], {
-          width: object.width,
-          height: object.height,
-        });
+
+  if (curr instanceof ClippingGroup) {
+    return curr;
+  }
+
+  const next = new ClippingGroup([], {
+    width: object.width,
+    height: object.height,
+  });
 
   if (curr) {
     const { x, y } = curr.translateToOriginPoint(


### PR DESCRIPTION
The function is supposed to return as is if it the clip path is already a clipping group