### PR TITLE
Fix clipping group

### DIFF
--- a/packages/fabric/src/EraserBrush.ts
+++ b/packages/fabric/src/EraserBrush.ts
@@ -41,8 +41,8 @@ const assertClippingGroup = (object: fabric.FabricObject) => {
   }
 
   const next = new ClippingGroup([], {
-    width: object.width,
-    height: object.height,
+    width: object.width + object.strokeWidth,
+    height: object.height + object.strokeWidth,
   });
 
   if (curr) {


### PR DESCRIPTION
When erase object paint with pencil brush, the clipping group did not count the object width, so if the brush width is big, there will be a rectangle immediately clipped around the stroke.