### PR TITLE
fix(): ClippingGroup size

### DIFF
--- a/packages/fabric/src/EraserBrush.ts
+++ b/packages/fabric/src/EraserBrush.ts
@@ -40,9 +40,15 @@ const assertClippingGroup = (object: fabric.FabricObject) => {
     return curr;
   }
 
+  // In order to support objects with stroke width, stroke uniform, shadow etc.
+  // we use the actual drawn size
+  const { width, height } = object._limitCacheSize(
+    object._getCacheCanvasDimensions()
+  );
+
   const next = new ClippingGroup([], {
-    width: object.width,
-    height: object.height,
+    width,
+    height,
   });
 
   if (curr) {


### PR DESCRIPTION
closes #26

In order to support objects with stroke width, stroke uniform, shadow etc. we use the actual drawn size which also includes anti aliasing padding.
I do not like this approach because it uses fabric caching which is ghastly.
We can handle different cases such as stroke width, as done in #26, support also stroke uniform, shadows but let's move forward like this and see if it is good enough.
