### PR TITLE
fix(ci): build `@erase2d/core`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6364,7 +6364,7 @@
     },
     "packages/fabric": {
       "name": "@erase2d/fabric",
-      "version": "1.1.0-1",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@erase2d/core": "file:../core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2048,6 +2048,31 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.1",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-terser": {
       "version": "0.4.4",
       "dev": true,
@@ -2465,6 +2490,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
@@ -2947,6 +2978,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -3422,6 +3465,15 @@
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/del": {
@@ -4027,6 +4079,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.13.1",
       "dev": true,
@@ -4080,6 +4147,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6293,8 +6366,9 @@
       "name": "@erase2d/fabric",
       "version": "1.1.0-1",
       "license": "MIT",
-      "dependencies": {
-        "@erase2d/core": "file:../core"
+      "devDependencies": {
+        "@erase2d/core": "file:../core",
+        "@rollup/plugin-node-resolve": "^15.2.3"
       },
       "peerDependencies": {
         "fabric": "^6.0.0-beta19"

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -1,5 +1,4 @@
 import { babel } from '@rollup/plugin-babel';
-import terser from '@rollup/plugin-terser';
 import ts from '@rollup/plugin-typescript';
 import del from 'rollup-plugin-delete';
 
@@ -16,7 +15,7 @@ export default [
       preserveModules: true,
       entryFileNames: '[name].js',
       sourcemap: true,
-      plugins: [terser()],
+      // plugins: [terser()],
     },
     plugins: [
       del({

--- a/packages/fabric/README.md
+++ b/packages/fabric/README.md
@@ -74,4 +74,6 @@ https://github.com/ShaMan123/erase2d/blob/4c9657f8e2d6c20e7274f49a8f8e6d907f9e02
 
 ## Dev
 
-see main [`README`](../../README.md).
+The build command will build [`src`](./src) and copy [`core`](../core/dist) into [`dist`](./dist).
+
+For the rest, see the main [`README`](../../README.md).

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -34,17 +34,18 @@
       "optional": false
     }
   },
-  "dependencies": {
-    "@erase2d/core": "file:../core"
+  "devDependencies": {
+    "@erase2d/core": "file:../core",
+    "@rollup/plugin-node-resolve": "^15.2.3"
   },
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/fabric/index.js",
+  "types": "./dist/fabric/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "types": "./dist/fabric/index.d.ts",
+      "import": "./dist/fabric/index.js",
       "require": null,
-      "default": "./dist/index.js"
+      "default": "./dist/fabric/index.js"
     }
   }
 }

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erase2d/fabric",
-  "version": "1.1.0-1",
+  "version": "1.1.1",
   "description": "Fabric.js erase2d bindings",
   "type": "module",
   "scripts": {

--- a/packages/fabric/rollup.config.mjs
+++ b/packages/fabric/rollup.config.mjs
@@ -1,5 +1,5 @@
 import { babel } from '@rollup/plugin-babel';
-import terser from '@rollup/plugin-terser';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 import ts from '@rollup/plugin-typescript';
 import del from 'rollup-plugin-delete';
 
@@ -16,12 +16,16 @@ export default [
       preserveModules: true,
       entryFileNames: '[name].js',
       sourcemap: true,
-      plugins: [terser()],
+      // plugins: [terser()],
     },
     plugins: [
       del({
         targets: ['dist/*'],
       }),
+
+      // resolve and build `@erase2d/core`
+      nodeResolve(),
+
       ts({
         noForceEmit: true,
         tsconfig: 'tsconfig.json',
@@ -33,6 +37,6 @@ export default [
         presets: [['@babel/env'], ['@babel/typescript']],
       }),
     ],
-    external: ['fabric', '@erase2d/core'],
+    external: ['fabric'],
   },
 ];


### PR DESCRIPTION
closes #31 

As mentioned in the issue `@erase2d/core` is a dependency but it is not published to npm or updated to a public version. I decided to skip that and build core as part of the bundle for the fabric binding via rollup and make core a dev dependency.
I am not sure this is the best way, maybe it is better to publish core, but for now it seems unnecessary because core doesn't really offer enough value on its own (only 2 very simple methods).

I have also removed minifying via the terser plugin.