### PR TITLE
fix(): ClippingGroup size

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ npm init -w ./packages/a
 ## Publish
 
 ```bash
+npm run prepublish
 npm -w @erase2d/fabric version <type>
 npm -w @erase2d/fabric publish
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -6364,7 +6364,7 @@
     },
     "packages/fabric": {
       "name": "@erase2d/fabric",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "devDependencies": {
         "@erase2d/core": "file:../core",

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erase2d/fabric",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Fabric.js erase2d bindings",
   "type": "module",
   "scripts": {

--- a/packages/fabric/src/EraserBrush.ts
+++ b/packages/fabric/src/EraserBrush.ts
@@ -40,15 +40,15 @@ const assertClippingGroup = (object: fabric.FabricObject) => {
     return curr;
   }
 
-  // In order to support objects with stroke width, stroke uniform, shadow etc.
-  // we use the actual drawn size
-  const { width, height } = object._limitCacheSize(
-    object._getCacheCanvasDimensions()
-  );
+  const strokeWidth = object.strokeWidth;
+  const strokeWidthFactor = new fabric.Point(strokeWidth, strokeWidth);
+  const strokeVector = object.strokeUniform
+    ? strokeWidthFactor.divide(object.getObjectScaling())
+    : strokeWidthFactor;
 
   const next = new ClippingGroup([], {
-    width,
-    height,
+    width: object.width + strokeVector.x,
+    height: object.height + strokeVector.y,
   });
 
   if (curr) {


### PR DESCRIPTION
closes #35

Revert "fix(): ClippingGroup size (#29)"

This reverts commit 48747a9cc78af4b094240fb53f1348d0dad8c766.