### PR TITLE
fix(): backgroundImage/overlayImage erasable

### DIFF
--- a/packages/fabric/src/EraserBrush.ts
+++ b/packages/fabric/src/EraserBrush.ts
@@ -366,10 +366,7 @@ export class EraserBrush extends fabric.PencilBrush {
             ],
           ] as const
         )
-          .filter(
-            ([object]) =>
-              object && (object.erasable === undefined || object.erasable)
-          )
+          .filter(([object]) => !!object?.erasable)
           .map(async ([object, vptFlag]) => {
             return [
               object,

--- a/packages/fabric/src/EraserBrush.ts
+++ b/packages/fabric/src/EraserBrush.ts
@@ -366,7 +366,10 @@ export class EraserBrush extends fabric.PencilBrush {
             ],
           ] as const
         )
-          .filter(([object]) => object)
+          .filter(
+            ([object]) =>
+              object && (object.erasable === undefined || object.erasable)
+          )
           .map(async ([object, vptFlag]) => {
             return [
               object,


### PR DESCRIPTION
I always appreciate the convenience of using this tool. I have fixed an issue where the erasable setting for backgroundImage/overlayImage was not being applied. Please review the changes.